### PR TITLE
Fix sidebar width at resolutions right below {{ theme_page_width }}

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -616,8 +616,13 @@ div.sphinxsidebar {
 
     div.body {
         min-height: 0;
-        min-width: auto;
+        min-width: auto; /* fixes width on small screens, breaks .hll */
         padding: 0;
+    }
+    
+    .hll {
+        /* "fixes" the breakage */
+        width: max-content;
     }
 
     .rtd_doc_footer {

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -576,7 +576,7 @@ div.sphinxsidebar {
     div.sphinxsidebar {
         display: block;
         float: none;
-        width: 102.5%;
+        width: unset;
         {%- if theme_fixed_sidebar|lower == 'true' %}
         margin: -20px -30px 20px -30px;
         position: static;

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -616,6 +616,7 @@ div.sphinxsidebar {
 
     div.body {
         min-height: 0;
+        min-width: auto;
         padding: 0;
     }
 

--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -636,7 +636,7 @@ div.sphinxsidebar {
     }
 
     ul {
-    	margin-left: 0;
+        margin-left: 0;
     }
 
     li > ul {


### PR DESCRIPTION
That 102.5% hack breaks at certain resolutions. Unsetting the width here makes it actually 100% wide and never too wide, thus a horizontal scrollbar never appears.